### PR TITLE
Use virtool/workflow:1.0.0 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM virtool/workflow:nightly
+FROM virtool/workflow:1.0.0
 
 WORKDIR /workflow
 


### PR DESCRIPTION
We should not use nightly as it is no longer published or current.